### PR TITLE
Increase player symbol size in tic tac toe tiles

### DIFF
--- a/styles/home.module.css
+++ b/styles/home.module.css
@@ -27,7 +27,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 24px;
+  font-size: 48px;
   cursor: pointer;
   transition: background-color 0.3s;
   animation: squareAnimation 1s infinite;


### PR DESCRIPTION
Increase the size of the player symbol in each tic tac toe tile/square.

* Increase the font size for the player symbol from 24px to 48px in the `.square` class in `styles/home.module.css`.
* Ensure the player symbols are centered within each square.